### PR TITLE
Config + DuraDisplay enabled on launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.idea/
 /run/
 /run-data/
+/out

--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ tasks.named('processResources', ProcessResources).configure {
                              loader_version_range: loader_version_range,
                              mod_id              : mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
                              mod_authors         : mod_authors, mod_description: mod_description,
-                             gtceu_version       : gtceu_version
+                             gtceu_version       : gtceu_version, configuration_version: configuration_version
     ]
 
     inputs.properties replaceProperties

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,10 @@ repositories {
         name "firstdarkdev"
         url "https://maven.firstdarkdev.xyz/snapshots"
     }
+    maven {
+        name = 'Toma Maven'
+        url "https://api.repsy.io/mvn/toma/public/"
+    }
 }
 
 dependencies {
@@ -115,6 +119,8 @@ dependencies {
     implementation fg.deobf("com.lowdragmc.ldlib:ldlib-forge-$minecraft_version:$ldlib_version") { transitive = false }
     implementation fg.deobf("appeng:appliedenergistics2-forge:$ae2_version")
     implementation fg.deobf("curse.maven:guideme-1173950:6679102")
+    implementation "dev.toma.configuration:configuration-$minecraft_version:$configuration_version-forge"
+
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
     compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:$mixinextras_version"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,4 @@ gtceu_version=7.1.3
 ldlib_version=1.0.41
 ae2_version=15.4.8
 mixinextras_version=0.4.1
+configuration_version=3.1.0

--- a/src/main/java/lu/kolja/duradisp/ModConfig.java
+++ b/src/main/java/lu/kolja/duradisp/ModConfig.java
@@ -1,0 +1,43 @@
+package lu.kolja.duradisp;
+
+import dev.toma.configuration.Configuration;
+import dev.toma.configuration.config.Config;
+import dev.toma.configuration.config.Configurable;
+import dev.toma.configuration.config.format.ConfigFormats;
+import lu.kolja.duradisp.enums.DisplayState;
+
+
+@Config(id = Duradisp.MODID)
+public class ModConfig {
+    public static ModConfig INSTANCE;
+    private static final Object LOCK = new Object();
+
+    public static void init() {
+        synchronized(LOCK) {
+            if (INSTANCE == null) {
+                INSTANCE = Configuration.registerConfig(ModConfig.class, ConfigFormats.YAML).getConfigInstance();
+            }
+        }
+    }
+
+    @Configurable
+    @Configurable.Comment(value = "Format to display durability in (percentage, number, scientific, vanilla)", localize = true)
+    public String displayState = "percentage";
+
+    public static void setDisplayState(String newFormat) {
+        ModConfig.INSTANCE.displayState = newFormat;
+    }
+
+    public static DisplayState getDisplayState() {
+        var str = ModConfig.INSTANCE.displayState.toLowerCase().trim();
+
+        return switch (str) {
+            case "vanilla" -> DisplayState.DISABLED;
+            case "percentage" -> DisplayState.ENABLED_PERCENTAGE;
+            case "number" -> DisplayState.ENABLED_NUMBER;
+            case "scientific" -> DisplayState.ENABLED_SCIENTIFIC;
+            default -> throw new IllegalArgumentException(
+                    "Invalid display format! Display state format must be vanilla, percentage, number, or scientific");
+        };
+    }
+}

--- a/src/main/java/lu/kolja/duradisp/mixins/MixinGuiGraphics.java
+++ b/src/main/java/lu/kolja/duradisp/mixins/MixinGuiGraphics.java
@@ -1,8 +1,8 @@
 package lu.kolja.duradisp.mixins;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import lu.kolja.duradisp.ModConfig;
 import lu.kolja.duradisp.enums.DisplayState;
-import lu.kolja.duradisp.misc.KeyMappings;
 import net.minecraft.client.gui.GuiGraphics;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -16,7 +16,8 @@ public class MixinGuiGraphics {
                     target = "Lnet/minecraft/world/item/ItemStack;isBarVisible()Z"
             )
     )
+
     private boolean isBarVisible(boolean isVisible) {
-        return KeyMappings.INSTANCE.getState() == DisplayState.DISABLED && isVisible;
+        return ModConfig.getDisplayState() == DisplayState.DISABLED && isVisible;
     }
 }

--- a/src/main/java/lu/kolja/duradisp/mixins/MixinToolChargeBarRenderer.java
+++ b/src/main/java/lu/kolja/duradisp/mixins/MixinToolChargeBarRenderer.java
@@ -2,8 +2,8 @@ package lu.kolja.duradisp.mixins;
 
 import com.gregtechceu.gtceu.api.item.IGTTool;
 import com.gregtechceu.gtceu.client.renderer.item.ToolChargeBarRenderer;
+import lu.kolja.duradisp.ModConfig;
 import lu.kolja.duradisp.enums.DisplayState;
-import lu.kolja.duradisp.misc.KeyMappings;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
@@ -35,6 +35,6 @@ public class MixinToolChargeBarRenderer {
 
     @Unique
     private static boolean duradisp$shouldRender() {
-        return KeyMappings.INSTANCE.getState() != DisplayState.DISABLED;
+        return ModConfig.getDisplayState() != DisplayState.DISABLED;
     }
 }

--- a/src/main/kotlin/lu/kolja/duradisp/Duradisp.kt
+++ b/src/main/kotlin/lu/kolja/duradisp/Duradisp.kt
@@ -16,6 +16,7 @@ class Duradisp {
 
     init {
         DisplayRegistry()
+        ModConfig.init()
     }
 
     @Mod.EventBusSubscriber(modid = MODID, bus = Mod.EventBusSubscriber.Bus.MOD, value = [Dist.CLIENT])

--- a/src/main/kotlin/lu/kolja/duradisp/enums/DisplayState.kt
+++ b/src/main/kotlin/lu/kolja/duradisp/enums/DisplayState.kt
@@ -1,10 +1,10 @@
 package lu.kolja.duradisp.enums
 
-enum class DisplayState {
-    DISABLED,
-    ENABLED_PERCENTAGE,
-    ENABLED_NUMBER,
-    ENABLED_SCIENTIFIC;
+enum class DisplayState(val configVal: String) {
+    DISABLED("vanilla"),
+    ENABLED_PERCENTAGE("percentage"),
+    ENABLED_NUMBER("number"),
+    ENABLED_SCIENTIFIC("scientific");
 
     companion object {
         private var index = 0

--- a/src/main/kotlin/lu/kolja/duradisp/misc/KeyMappings.kt
+++ b/src/main/kotlin/lu/kolja/duradisp/misc/KeyMappings.kt
@@ -2,6 +2,7 @@ package lu.kolja.duradisp.misc
 
 import com.mojang.blaze3d.platform.InputConstants
 import lu.kolja.duradisp.Duradisp.Companion.MODID
+import lu.kolja.duradisp.ModConfig
 import lu.kolja.duradisp.enums.DisplayState
 import net.minecraft.client.KeyMapping
 import net.minecraftforge.api.distmarker.Dist
@@ -29,15 +30,13 @@ object KeyMappings {
         event.register(CLIENT_MAPPINGS)
     }
 
-    var state = DisplayState.DISABLED
-
     @Mod.EventBusSubscriber(modid = MODID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = [Dist.CLIENT])
     object ForgeClient {
         @SubscribeEvent
         fun onClientTick(event: TickEvent.ClientTickEvent) {
             if (event.phase != TickEvent.Phase.END) return
             while (CLIENT_MAPPINGS.consumeClick()) {
-                state = DisplayState.getNext()
+                ModConfig.setDisplayState(DisplayState.getNext().configVal)
             }
         }
     }

--- a/src/main/kotlin/lu/kolja/duradisp/render/DisplayRenderer.kt
+++ b/src/main/kotlin/lu/kolja/duradisp/render/DisplayRenderer.kt
@@ -1,8 +1,8 @@
 package lu.kolja.duradisp.render
 
+import lu.kolja.duradisp.ModConfig
 import lu.kolja.duradisp.enums.DisplayState.*
 import lu.kolja.duradisp.logic.DisplayStore
-import lu.kolja.duradisp.misc.KeyMappings
 import lu.kolja.duradisp.misc.NumberUtil
 import lu.kolja.duradisp.registry.DisplayRegistry
 import net.minecraft.client.Minecraft
@@ -21,7 +21,7 @@ class DisplayRenderer: IItemDecorator {
     ): Boolean {
         if (stack == null || stack.isEmpty)
             return false
-        return when (KeyMappings.state) {
+        return when (ModConfig.getDisplayState()) {
             ENABLED_PERCENTAGE -> {
                 renderActual(
                     stack, guiGraphics, font,

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -30,6 +30,6 @@ side = "BOTH"
 [[dependencies."${mod_id}"]]
 modId = "configuration"
 mandatory = true
-versionRange = "${configuration_version}"
+versionRange = "[3.0, ${configuration_version}]"
 ordering = "BEFORE"
 side = "CLIENT"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -30,6 +30,6 @@ side = "BOTH"
 [[dependencies."${mod_id}"]]
 modId = "configuration"
 mandatory = true
-versionRange = "[3.0, ${configuration_version}]"
-ordering = "BEFORE"
+versionRange = "${configuration_version}"
+ordering = "NONE"
 side = "CLIENT"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -27,3 +27,9 @@ mandatory = false
 versionRange = "[${gtceu_version},)"
 ordering = "AFTER"
 side = "BOTH"
+[[dependencies."${mod_id}"]]
+modId = "configuration"
+mandatory = true
+versionRange = "${configuration_version}"
+ordering = "BEFORE"
+side = "CLIENT"

--- a/src/main/resources/assets/duradisplay/lang/en_us.json
+++ b/src/main/resources/assets/duradisplay/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "key.categories.duradisp": "Dura: ReDisplayed",
+  "key.duradisp.switch_bar_display": "Switch Display Format",
+  "config.screen.duradisp": "Dura: ReDisplayed Config",
+  "config.duradisp.option.displayState": "Display State Format",
+  "config.duradisp.option.displayState.comment.0": "Format to display durability in (percentage, number, scientific, vanilla)"
+}


### PR DESCRIPTION
Uses Configuration to define the current display state. Can be cycled by pressing the keybind. Also adds localisation for missing lang keys

Bonus: Adds out/ to gitignore

NOTE: Configuration is currently defined as a dependency, this can also be a JiJ (like how GTM does)